### PR TITLE
Set up browser launchers for TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: node_js
+env:
+  - BROWSER=ChromeCi
+  - BROWSER=Firefox
 node_js:
   - node
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 sudo: false
+
 language: node_js
+
+node_js:
+  - node
+
+cache:
+  directories:
+    - node_modules
+
 env:
   - BROWSER=ChromeCi
   - BROWSER=Firefox
-node_js:
-  - node
+
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -69,7 +69,13 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
+    browsers: env.BROWSER ? env.BROWSER.split(',') : ['Chrome'],
+    customLaunchers: {
+      ChromeCi: {
+        base: 'Chrome',
+        flags: ['--no-sandbox'],
+      },
+    },
 
 
     // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -69,7 +69,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: env.BROWSER ? env.BROWSER.split(',') : ['Chrome'],
+    browsers: process.env.BROWSER ? process.env.BROWSER.split(',') : ['Chrome'],
     customLaunchers: {
       ChromeCi: {
         base: 'Chrome',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chai": "^3.5.0",
     "karma": "^1.3.0",
     "karma-chrome-launcher": "^2.0.0",
+    "karma-firefox-launcher": "^1.0.0",
     "karma-mocha": "^1.2.0",
     "karma-mocha-reporter": "^2.2.0",
     "karma-webpack": "^1.8.0",


### PR DESCRIPTION
Summary:
------

This is basic setup to allow for proper testing on Firefox and Chrome on TravisCI. The node tests should work without problem as well.