### PR TITLE
Enforce strict beginnings & ends of wildcard string patterns

### DIFF
--- a/tests/wildcardRegex.js
+++ b/tests/wildcardRegex.js
@@ -52,7 +52,7 @@ describe('wildcardRegex', function() {
       expect(regexEmptyString.test(incorrectTestString)).to.equal(false);
     });
 
-    it('does not test for wildcards if no asterisks exist', function() {
+    it('tests strictly & does not test for wildcards if no asterisks exist', function() {
       var wildcardString = 'github.com/kevinzwhuang/wildcard-regex';
       var regex = wildcardRegex(wildcardString);
       var correctTestString = 'github.com/kevinzwhuang/wildcard-regex';
@@ -90,6 +90,16 @@ describe('wildcardRegex', function() {
       expect(regexEmptyArray.test('')).to.equal(true);
       expect(regexEmptyArray.test('test')).to.equal(true);
       expect(regexEmptyArray.test('this will not pass')).to.equal(false);
+    });
+
+    it('tests strictly & does not test for wildcards if no asterisks exist', function() {
+      var wildcardArray = ['github.com', 'wikipedia'];
+      var regex = wildcardRegex(wildcardArray);
+
+      expect(regex.test('github.com')).to.equal(true);
+      expect(regex.test('wikipedia')).to.equal(true);
+      expect(regex.test('www.github.com')).to.equal(false);
+      expect(regex.test('www.wikipedia.com')).to.equal(false);
     });
 
   });

--- a/tests/wildcardRegex.js
+++ b/tests/wildcardRegex.js
@@ -52,6 +52,18 @@ describe('wildcardRegex', function() {
       expect(regexEmptyString.test(incorrectTestString)).to.equal(false);
     });
 
+    it('does not test for wildcards if no asterisks exist', function() {
+      var wildcardString = 'github.com/kevinzwhuang/wildcard-regex';
+      var regex = wildcardRegex(wildcardString);
+      var correctTestString = 'github.com/kevinzwhuang/wildcard-regex';
+      var incorrectTestString = 'https://github.com/kevinzwhuang/wildcard-regex';
+      var incorrectTestString2 = 'https://github.com/kevinzwhuang/wildcard-regex/blob/master/wildcard-regex.js';
+
+      expect(regex.test(correctTestString)).to.equal(true);
+      expect(regex.test(incorrectTestString)).to.equal(false);
+      expect(regex.test(incorrectTestString2)).to.equal(false);
+    });
+
   });
 
   describe('when called with an Array of strings', function() {

--- a/wildcard-regex.js
+++ b/wildcard-regex.js
@@ -3,19 +3,16 @@
 function transformWildcardToPattern(wildcardString) {
   var length = wildcardString.length;
   var character;
-  var pattern = '';
-  if(wildcardString === '') {
-    pattern = '^$';
-  } else {
-    for (var index = 0; index < length; index++) {
-      character = wildcardString.charAt(index);
-      if (character === '*') {
-        pattern = pattern + '.*'
-      } else {
-        pattern = pattern + character;
-      }
+  var pattern = '^';
+  for (var index = 0; index < length; index++) {
+    character = wildcardString.charAt(index);
+    if (character === '*') {
+      pattern = pattern + '.*'
+    } else {
+      pattern = pattern + character;
     }
   }
+  pattern = pattern + '$';
   return pattern;
 };
 


### PR DESCRIPTION
Summary:
------

Previously, wildcard strings with missing asterisks at the beginning and ends of the patterns would still test `true` with `.test` - which is incorrect.

For example:
The wildcard pattern provided as `'github'` would test true when tested against `www.github.com` since we did not use `^` or `$` to enforce the starts and ends of patterns.

This PR corrects this behavior.