### PR TITLE
Fix missing dist folder by adding files array to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "3.0.0",
   "description": "Super simple wildcard tools for generating string patterns and RegExp objects",
   "main": "/dist/wildcard-regex.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "build": "npm run webpack:dev && npm run webpack:prod",
     "test": "echo \"Running backend Node tests\" && npm run test:node && echo \"Running frontend browser tests\" && npm run test:browser",


### PR DESCRIPTION
Summary
-------

The NPM package for `wildcard-regex` was breaking because it was missing the `dist` folder. This should fix it by explicitly including it in `package.json`.